### PR TITLE
fix "Parse error: syntax error, unexpected 'do' (T_DO), expecting identifier"

### DIFF
--- a/src/DBD.php
+++ b/src/DBD.php
@@ -227,7 +227,7 @@ abstract class DBD
         }
     */
 
-    public function do() {
+    public function doit() {
         if(!func_num_args())
             trigger_error("query failed: statement is not set or empty", E_USER_ERROR);
 
@@ -253,7 +253,7 @@ abstract class DBD
      * @deprecated
      */
     public function du() {
-        return $this->do(func_get_args());
+        return $this->doit(func_get_args());
     }
 
     /**


### PR DESCRIPTION
fix Parse error: syntax error, unexpected 'do' (T_DO), expecting identifier  'DBD.php' on line 230 for php version 5.6.30